### PR TITLE
Feature/env settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ SLA Manager (java backend) needs to be running in order to use the dashboard.
 
 ## Settings ##
 
-* sladashboard/settings.py:
+* sladashboard/settings.py (overridable with env vars of the same name):
     - SLA_MANAGER_URL : The URL of the SLA Manager REST interface.
     - DEBUG: Please, set this to FALSE in production
 
@@ -94,27 +94,6 @@ NOTE: this steps are not suitable in production mode.
     # Test
     #
     curl http://localhost:8000/slagui/agreements/
-
-## REST Facade Example ##
-
-Initial conditions:
-
-* Brooklyn is running and nuro application is deployed.
-* Sla-core is running and loaded with `nuro-template` template:
-
-
-    cd $SLA_CORE && bin/restoreDatabase.sh && bin/load-nuro-samples.sh
-
-To create an agreement from that template and start the enforcement:
-
-    cd $SLA_DASHBOARD
-    SLA_DASHBOARD_URL=http://localhost:8000 bin/load-nuro-samples.sh \
-        nuro-template random-client $appid $moduleid
-
-, where $appid and $moduleid are the ids of the brooklyn application and
-brooklyn php module, respectively.
-
-Check agreement creation in $SLA_DASHBOARD_URL/slagui/agreements
 
 ##License##
 

--- a/sladashboard/settings.py
+++ b/sladashboard/settings.py
@@ -94,8 +94,11 @@ PORTALINSTANCE = False
 #
 
 # SlaManager root url
-SLA_MANAGER_URL="http://127.0.0.1:8080/sla-service"
+SLA_MANAGER_URL=os.environ.get("SLA_MANAGER_URL", "http://127.0.0.1:8080/sla-service")
 # Development Internal IPs
 INTERNAL_IPS=("127.0.0.1",)
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+#
+# DEBUG is True is env var DEBUG is defined and not equal to empty string
+#
+DEBUG = bool(os.environ.get('DEBUG', False))


### PR DESCRIPTION
The sla-core endpoint is now configurable with SLA_MANAGER_URL.

Needed for a brooklyn deployment.
